### PR TITLE
Fix parsing and editing of empty mappings

### DIFF
--- a/src/yaml/data.rs
+++ b/src/yaml/data.rs
@@ -279,7 +279,7 @@ impl Data {
     }
 
     /// Replace with indentation.
-    pub(crate) fn replace_with(&mut self, id: Id, raw: raw::Raw, prefix: StringId) {
+    pub(crate) fn replace_with(&mut self, id: Id, prefix: StringId, raw: raw::Raw) {
         let Some(value) = self.slab.get_mut(id.get()) else {
             return;
         };

--- a/src/yaml/document.rs
+++ b/src/yaml/document.rs
@@ -259,9 +259,8 @@ impl Document {
         use std::fmt::Display;
 
         self.data.prefix(self.root).fmt(f)?;
-        self.data.raw(self.root).display(&self.data, f)?;
+        self.data.raw(self.root).display(&self.data, f, None)?;
         self.data.str(self.suffix).fmt(f)?;
-
         Ok(())
     }
 }

--- a/src/yaml/mapping/mapping.rs
+++ b/src/yaml/mapping/mapping.rs
@@ -234,7 +234,7 @@ impl<'a> Mapping<'a> {
 impl fmt::Display for Mapping<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.data.mapping(self.id).display(self.data, f)
+        self.data.mapping(self.id).display(self.data, f, None)
     }
 }
 

--- a/src/yaml/mapping/mapping_mut.rs
+++ b/src/yaml/mapping/mapping_mut.rs
@@ -188,6 +188,7 @@ impl<'a> MappingMut<'a> {
 
         self.data
             .replace(item_id, Raw::MappingItem(raw::MappingItem { key, value }));
+
         self.data.mapping_mut(self.id).items.push(item_id);
         value
     }

--- a/src/yaml/sequence/sequence.rs
+++ b/src/yaml/sequence/sequence.rs
@@ -314,7 +314,7 @@ impl<'a> Sequence<'a> {
 impl fmt::Display for Sequence<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.data.sequence(self.id).display(self.data, f)
+        self.data.sequence(self.id).display(self.data, f, None)
     }
 }
 

--- a/src/yaml/sequence/sequence_mut.rs
+++ b/src/yaml/sequence/sequence_mut.rs
@@ -347,10 +347,7 @@ impl<'a> SequenceMut<'a> {
     ///
     /// root.clear();
     ///
-    /// assert_eq!(
-    ///     doc.to_string(),
-    ///     "\n    \n    "
-    /// );
+    /// assert_eq!(doc.to_string(), "\n    \n    ");
     /// # Ok::<_, anyhow::Error>(())
     /// ```
     pub fn clear(&mut self) {

--- a/src/yaml/tests/mapping.rs
+++ b/src/yaml/tests/mapping.rs
@@ -99,3 +99,34 @@ fn make_preserve_whitespace() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn edit_element() -> Result<()> {
+    let mut doc = yaml::from_slice("a:\nb:\nc:")?;
+
+    let mapping = doc.as_ref().as_mapping().context("Missing root mapping")?;
+
+    assert_eq!(mapping.len(), 3);
+
+    let a = mapping.get("a").context("Missing a")?;
+
+    let id = a.id();
+
+    let _ = doc.value_mut(id).make_mapping();
+
+    assert_eq!(doc.to_string(), "a:\nb:\nc:");
+
+    let mut mapping = doc
+        .value_mut(id)
+        .into_mapping_mut()
+        .context("Missing mapping")?;
+
+    let mut sequence = mapping
+        .insert("inner", yaml::Separator::Auto)
+        .make_sequence();
+
+    sequence.push_string("value");
+
+    assert_eq!(doc.to_string(), "a:\n  inner:\n    - value\nb:\nc:");
+    Ok(())
+}

--- a/src/yaml/value.rs
+++ b/src/yaml/value.rs
@@ -118,12 +118,25 @@ pub enum Null {
 }
 
 impl Null {
-    pub(crate) fn display(self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub(crate) fn display(
+        self,
+        data: &Data,
+        f: &mut fmt::Formatter<'_>,
+        prefix: Option<Id>,
+    ) -> fmt::Result {
         match self {
             Null::Keyword => {
+                if let Some(id) = prefix {
+                    write!(f, "{}", data.prefix(id))?;
+                }
+
                 write!(f, "null")?;
             }
             Null::Tilde => {
+                if let Some(id) = prefix {
+                    write!(f, "{}", data.prefix(id))?;
+                }
+
                 write!(f, "~")?;
             }
             Null::Empty => {
@@ -569,7 +582,7 @@ impl<'a> Value<'a> {
 impl fmt::Display for Value<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.data.raw(self.id).display(self.data, f)
+        self.data.raw(self.id).display(self.data, f, None)
     }
 }
 
@@ -580,7 +593,10 @@ impl fmt::Debug for Value<'_> {
         impl fmt::Debug for Display<'_, '_> {
             #[inline]
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                self.0.data.raw(self.0.id).display(self.0.data, f)
+                self.0
+                    .data
+                    .raw(self.0.id)
+                    .display(self.0.data, f, Some(self.0.id))
             }
         }
 

--- a/src/yaml/value_mut.rs
+++ b/src/yaml/value_mut.rs
@@ -657,13 +657,15 @@ impl<'a> ValueMut<'a> {
         if !matches!(self.data.raw(self.id), Raw::Mapping(..)) {
             let (indent, prefix) = raw::make_indent(self.data, self.id, 0);
 
-            let value = Raw::Mapping(raw::Mapping {
-                indent,
-                kind: raw::MappingKind::Mapping,
-                items: Vec::new(),
-            });
-
-            self.data.replace_with(self.id, value, prefix);
+            self.data.replace_with(
+                self.id,
+                prefix,
+                Raw::Mapping(raw::Mapping {
+                    indent,
+                    kind: raw::MappingKind::Mapping,
+                    items: Vec::new(),
+                }),
+            );
         }
 
         MappingMut::new(self.data, self.id)
@@ -721,13 +723,15 @@ impl<'a> ValueMut<'a> {
         if !matches!(self.data.raw(self.id), Raw::Sequence(..)) {
             let (indent, prefix) = raw::make_indent(self.data, self.id, 0);
 
-            let raw = Raw::Sequence(raw::Sequence {
-                indent,
-                kind: raw::SequenceKind::Mapping,
-                items: Vec::new(),
-            });
-
-            self.data.replace_with(self.id, raw, prefix);
+            self.data.replace_with(
+                self.id,
+                prefix,
+                Raw::Sequence(raw::Sequence {
+                    indent,
+                    kind: raw::SequenceKind::Mapping,
+                    items: Vec::new(),
+                }),
+            );
         }
 
         SequenceMut::new(self.data, self.id)


### PR DESCRIPTION
This fixes cases like these, which at first glance appears to parse and serialize correctly:

```
a:
b:
```

But with the current implementation, is actually treated like this:

```
a: {b: null}
```

When it should be:

```
a: null
b: null
```

Where null above is the empty null, rather than the explicit keyword `null`.

I've also ensured that during serialization, empty elements which can only be constructed through APIs like `make_mapping` / `make_sequence` are not serialized.