### PR TITLE
More idiomatic mappings inside of sequence items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@
 //! use nondestructive::yaml;
 //!
 //! let mut doc = yaml::from_slice(
-//!     r#"
+//!     r"
 //!     greeting: Hello World!
-//!     "#
+//!     "
 //! )?;
 //!
 //! // Access through the document:
@@ -50,10 +50,10 @@
 //!
 //! assert_eq!(
 //!     doc.to_string(),
-//!     r#"
+//!     r"
 //!     greeting: Hello World!
 //!     greeting2: Hello Rust!
-//!     "#
+//!     "
 //! );
 //! # Ok::<_, anyhow::Error>(())
 //! ```
@@ -98,11 +98,11 @@
 //! use nondestructive::yaml;
 //!
 //! let mut doc = yaml::from_slice(
-//!     r#"
+//!     r"
 //!     - 10
 //!     - 24
 //!     - 30
-//!     "#
+//!     "
 //! )?;
 //!
 //! let mut edits = Vec::new();
@@ -125,11 +125,11 @@
 //!
 //! assert_eq!(
 //!     doc.to_string(),
-//!     r#"
+//!     r"
 //!     - 1
 //!     - 24
 //!     - 3
-//!     "#
+//!     "
 //! );
 //! # Ok::<_, anyhow::Error>(())
 //! ```
@@ -148,10 +148,10 @@
 //! use nondestructive::yaml;
 //!
 //! let mut doc = yaml::from_slice(
-//!     r#"
+//!     r"
 //!     name: Descartes
 //!     country: Grece
-//!     "#
+//!     "
 //! )?;
 //!
 //! let mapping = doc.as_ref().as_mapping().context("missing mapping")?;
@@ -167,10 +167,10 @@
 //!
 //! assert_eq!(
 //!     doc.to_string(),
-//!     r#"
+//!     r"
 //!     name: Plato
 //!     country: Greece
-//!     "#
+//!     "
 //! );
 //! # Ok::<_, anyhow::Error>(())
 //! ```

--- a/src/yaml/any.rs
+++ b/src/yaml/any.rs
@@ -25,10 +25,10 @@ impl Any<'_> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - 10
     ///     - 20
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let id = doc.as_ref().into_any().id();

--- a/src/yaml/any_mut.rs
+++ b/src/yaml/any_mut.rs
@@ -24,10 +24,10 @@ impl AnyMut<'_> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - 10
     ///     - 20
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let id = doc.as_mut().into_any_mut().id();

--- a/src/yaml/data.rs
+++ b/src/yaml/data.rs
@@ -119,7 +119,7 @@ impl Data {
             return &raw.layout;
         }
 
-        panic!("expected raw at {id}")
+        panic!("expected layout at {id}")
     }
 
     #[inline]
@@ -203,7 +203,7 @@ impl Data {
             return raw;
         }
 
-        panic!("expected mapping at {id}")
+        panic!("expected sequence item at {id}")
     }
 
     #[inline]
@@ -216,7 +216,7 @@ impl Data {
             return raw;
         }
 
-        panic!("expected mapping at {id}")
+        panic!("expected mapping item at {id}")
     }
 
     #[inline]

--- a/src/yaml/document.rs
+++ b/src/yaml/document.rs
@@ -75,10 +75,10 @@ impl Document {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     first: 32
     ///     second: [1, 2, 3]
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let root = doc.as_ref().as_mapping().context("missing mapping")?;
@@ -100,10 +100,10 @@ impl Document {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     first: 32
     ///     second: [1, 2, 3]
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let root = doc.as_ref().as_mapping().context("missing mapping")?;
@@ -136,10 +136,10 @@ impl Document {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     first: 32
     ///     second: [1, 2, 3]
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let root = doc.as_ref().as_mapping().context("missing mapping")?;
@@ -161,10 +161,10 @@ impl Document {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     first: 32
     ///     second: [1, 2, 3]
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let root = doc.as_ref().as_mapping().context("missing mapping")?;
@@ -176,10 +176,10 @@ impl Document {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     first: 32
     ///     second: Hello World
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -201,9 +201,9 @@ impl Document {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     string
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut mapping = doc.as_mut().make_mapping();
@@ -215,16 +215,16 @@ impl Document {
     ///
     /// assert_eq!(
     ///     &out[..],
-    ///     br#"
+    ///     br"
     ///     first: 1
     ///     second: 2
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     first: second
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut mapping = doc.as_mut().into_mapping_mut().and_then(|m| Some(m.get_into_mut("first")?.make_mapping())).context("missing first")?;
@@ -236,11 +236,11 @@ impl Document {
     ///
     /// assert_eq!(
     ///     &out[..],
-    ///     br#"
+    ///     br"
     ///     first:
     ///       second: 2
     ///       third: 3
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```

--- a/src/yaml/error.rs
+++ b/src/yaml/error.rs
@@ -56,10 +56,10 @@ pub enum ErrorKind {
     /// use anyhow::Context;
     /// use nondestructive::yaml;
     ///
-    /// const INPUT: &str = r#"
+    /// const INPUT: &str = r"
     /// {hello: world}
     /// 42
-    /// "#;
+    /// ";
     ///
     /// let error = yaml::from_slice(INPUT).unwrap_err();
     /// assert_eq!(*error.kind(), yaml::ErrorKind::ExpectedEof);
@@ -73,7 +73,7 @@ pub enum ErrorKind {
     /// ```
     /// use nondestructive::yaml;
     ///
-    /// const INPUT: &str = r#"[Aristotle, # this is a comment"#;
+    /// const INPUT: &str = r"[Aristotle, # this is a comment";
     ///
     /// let error = yaml::from_slice(INPUT).unwrap_err();
     /// assert_eq!(*error.kind(), yaml::ErrorKind::BadSequenceTerminator);
@@ -87,7 +87,7 @@ pub enum ErrorKind {
     /// ```
     /// use nondestructive::yaml;
     ///
-    /// const INPUT: &str = r#"{name: Aristotle, age # this is a comment"#;
+    /// const INPUT: &str = r"{name: Aristotle, age # this is a comment";
     ///
     /// let error = yaml::from_slice(INPUT).unwrap_err();
     /// assert_eq!(*error.kind(), yaml::ErrorKind::BadMappingSeparator);
@@ -99,9 +99,9 @@ pub enum ErrorKind {
     /// ```
     /// use nondestructive::yaml;
     ///
-    /// const INPUT: &str = r#"
+    /// const INPUT: &str = r"
     /// name: Aristotle
-    /// age # end"#;
+    /// age # end";
     ///
     /// let error = yaml::from_slice(INPUT).unwrap_err();
     /// assert_eq!(*error.kind(), yaml::ErrorKind::BadMappingSeparator);
@@ -115,7 +115,7 @@ pub enum ErrorKind {
     /// ```
     /// use nondestructive::yaml;
     ///
-    /// const INPUT: &str = r#"{name: Aristotle, # this is a comment"#;
+    /// const INPUT: &str = r"{name: Aristotle, # this is a comment";
     ///
     /// let error = yaml::from_slice(INPUT).unwrap_err();
     /// assert_eq!(*error.kind(), yaml::ErrorKind::BadMappingTerminator);

--- a/src/yaml/mapping/mapping_mut.rs
+++ b/src/yaml/mapping/mapping_mut.rs
@@ -61,9 +61,9 @@ macro_rules! insert_float {
         /// use nondestructive::yaml;
         ///
         /// let mut doc = yaml::from_slice(
-        ///     r#"
+        ///     r"
         ///     number1: 10
-        ///     "#
+        ///     "
         /// )?;
         ///
         /// let mut value = doc.as_mut().into_mapping_mut().context("not a mapping")?;
@@ -71,10 +71,10 @@ macro_rules! insert_float {
         ///
         /// assert_eq!(
         ///     doc.to_string(),
-        ///     r#"
+        ///     r"
         ///     number1: 10
         #[doc = concat!("    number2: ", stringify!($lit))]
-        ///     "#
+        ///     "
         /// );
         /// # Ok::<_, anyhow::Error>(())
         /// ```
@@ -101,9 +101,9 @@ macro_rules! insert_number {
         /// use nondestructive::yaml;
         ///
         /// let mut doc = yaml::from_slice(
-        ///     r#"
+        ///     r"
         ///     number1: 10
-        ///     "#
+        ///     "
         /// )?;
         ///
         /// let mut value = doc.as_mut().into_mapping_mut().context("not a mapping")?;
@@ -112,10 +112,10 @@ macro_rules! insert_number {
         ///
         /// assert_eq!(
         ///     doc.to_string(),
-        ///     r#"
+        ///     r"
         ///     number1: 10
         #[doc = concat!("    number2: ", stringify!($lit))]
-        ///     "#
+        ///     "
         /// );
         /// # Ok::<_, anyhow::Error>(())
         /// ```
@@ -466,10 +466,10 @@ impl<'a> MappingMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     one: 1
     ///     two: 2
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let mut root = doc.as_mut().into_mapping_mut().context("missing root mapping")?;
@@ -477,11 +477,11 @@ impl<'a> MappingMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     one: 1
     ///     two: 2
     ///     three:   3
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -502,9 +502,9 @@ impl<'a> MappingMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     number1: 10
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut value = doc.as_mut().into_mapping_mut().context("not a mapping")?;
@@ -512,10 +512,10 @@ impl<'a> MappingMut<'a> {
     ///
     /// assert_eq! (
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     number1: 10
     ///     string2: hello
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -541,9 +541,9 @@ impl<'a> MappingMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     string
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut sequence = doc.as_mut().make_mapping();
@@ -553,12 +553,12 @@ impl<'a> MappingMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     key: |
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_mapping();
@@ -568,12 +568,12 @@ impl<'a> MappingMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     key: |+
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_mapping();
@@ -583,12 +583,12 @@ impl<'a> MappingMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     key: |-
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_mapping();
@@ -598,12 +598,12 @@ impl<'a> MappingMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     key: >
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_mapping();
@@ -613,12 +613,12 @@ impl<'a> MappingMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     key: >+
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_mapping();
@@ -628,12 +628,12 @@ impl<'a> MappingMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     key: >-
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -656,9 +656,9 @@ impl<'a> MappingMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     number1: 10
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut value = doc.as_mut().into_mapping_mut().context("not a mapping")?;
@@ -666,10 +666,10 @@ impl<'a> MappingMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     number1: 10
     ///     bool2: true
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```

--- a/src/yaml/sequence/sequence.rs
+++ b/src/yaml/sequence/sequence.rs
@@ -13,11 +13,11 @@ use crate::yaml::Value;
 /// use nondestructive::yaml;
 ///
 /// let doc = yaml::from_slice(
-///     r#"
+///     r"
 ///     - one
 ///     - two
 ///     - three
-///     "#,
+///     ",
 /// )?;
 ///
 /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -35,14 +35,14 @@ use crate::yaml::Value;
 /// use nondestructive::yaml;
 ///
 /// let doc = yaml::from_slice(
-///     r#"
+///     r"
 ///     - one
 ///     - two
 ///     - - three
 ///       - four: 2
 ///         five: 1
 ///     - six
-///     "#,
+///     ",
 /// )?;
 ///
 /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -85,9 +85,9 @@ use crate::yaml::Value;
 /// assert_eq!(doc.to_string(), "[,]");
 ///
 /// let doc = yaml::from_slice(
-///     r#"
+///     r"
 ///     [one, two, 3,]
-///     "#,
+///     ",
 /// )?;
 ///
 /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -97,9 +97,9 @@ use crate::yaml::Value;
 ///
 /// assert_eq!(
 ///     doc.to_string(),
-///     r#"
+///     r"
 ///     [one, two, 3,]
-///     "#
+///     "
 /// );
 /// # Ok::<_, anyhow::Error>(())
 /// ```
@@ -122,10 +122,10 @@ impl<'a> Sequence<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - 32
     ///     - [1, 2, 3]
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let root = doc.as_ref().as_sequence().context("missing sequence")?;
@@ -152,11 +152,11 @@ impl<'a> Sequence<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -178,11 +178,11 @@ impl<'a> Sequence<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -204,11 +204,11 @@ impl<'a> Sequence<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -235,11 +235,11 @@ impl<'a> Sequence<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -264,11 +264,11 @@ impl<'a> Sequence<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -293,11 +293,11 @@ impl<'a> Sequence<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -334,11 +334,11 @@ impl fmt::Debug for Sequence<'_> {
 /// use nondestructive::yaml;
 ///
 /// let doc = yaml::from_slice(
-///     r#"
+///     r"
 ///     - one
 ///     - two
 ///     - three
-///     "#,
+///     ",
 /// )?;
 ///
 /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;
@@ -364,11 +364,11 @@ impl<'a> IntoIterator for Sequence<'a> {
 /// use nondestructive::yaml;
 ///
 /// let doc = yaml::from_slice(
-///     r#"
+///     r"
 ///     - one
 ///     - two
 ///     - three
-///     "#,
+///     ",
 /// )?;
 ///
 /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;

--- a/src/yaml/sequence/sequence_mut.rs
+++ b/src/yaml/sequence/sequence_mut.rs
@@ -21,9 +21,9 @@ macro_rules! push_float {
         /// use nondestructive::yaml;
         ///
         /// let mut doc = yaml::from_slice(
-        ///     r#"
+        ///     r"
         ///     - 10
-        ///     "#
+        ///     "
         /// )?;
         ///
         /// let mut value = doc.as_mut().into_sequence_mut().context("not a sequence")?;
@@ -31,10 +31,10 @@ macro_rules! push_float {
         #[doc = concat!("value.", stringify!($name), "(", stringify!($lit), ");")]
         /// assert_eq!(
         ///     doc.to_string(),
-        ///     r#"
+        ///     r"
         ///     - 10
         #[doc = concat!("    - ", $lit)]
-        ///     "#
+        ///     "
         /// );
         /// # Ok::<_, anyhow::Error>(())
         /// ```
@@ -58,9 +58,9 @@ macro_rules! push_number {
         /// use nondestructive::yaml;
         ///
         /// let mut doc = yaml::from_slice(
-        ///     r#"
+        ///     r"
         ///     - 10
-        ///     "#
+        ///     "
         /// )?;
         ///
         /// let mut value = doc.as_mut().into_sequence_mut().context("not a sequence")?;
@@ -69,10 +69,10 @@ macro_rules! push_number {
         ///
         /// assert_eq!(
         ///     doc.to_string(),
-        ///     r#"
+        ///     r"
         ///     - 10
         #[doc = concat!("    - ", stringify!($lit))]
-        ///     "#
+        ///     "
         /// );
         /// # Ok::<_, anyhow::Error>(())
         /// ```
@@ -145,11 +145,11 @@ impl<'a> SequenceMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let root = doc.as_mut().into_sequence_mut().context("missing root sequence")?;
@@ -176,11 +176,11 @@ impl<'a> SequenceMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let root = doc.as_mut().into_sequence_mut().context("missing root sequence")?.into_ref();
@@ -371,10 +371,10 @@ impl<'a> SequenceMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let mut root = doc.as_mut().into_sequence_mut().context("missing root sequence")?;
@@ -382,11 +382,11 @@ impl<'a> SequenceMut<'a> {
     ///
     /// assert_eq! {
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     -   true
-    ///     "#
+    ///     "
     /// };
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -404,9 +404,9 @@ impl<'a> SequenceMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - - 10
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut value = doc.as_mut().into_sequence_mut().context("not a sequence")?;
@@ -415,10 +415,10 @@ impl<'a> SequenceMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - - 10
     ///       - nice string
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -443,9 +443,9 @@ impl<'a> SequenceMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     string
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut sequence = doc.as_mut().make_sequence();
@@ -455,12 +455,12 @@ impl<'a> SequenceMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - |
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_sequence();
@@ -470,12 +470,12 @@ impl<'a> SequenceMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - |+
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_sequence();
@@ -485,12 +485,12 @@ impl<'a> SequenceMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - |-
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_sequence();
@@ -500,12 +500,12 @@ impl<'a> SequenceMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - >
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_sequence();
@@ -515,12 +515,12 @@ impl<'a> SequenceMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - >+
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut sequence = doc.as_mut().make_sequence();
@@ -530,12 +530,12 @@ impl<'a> SequenceMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - >-
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -557,9 +557,9 @@ impl<'a> SequenceMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - - 10
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut value = doc.as_mut().into_sequence_mut().context("not a sequence")?;
@@ -568,10 +568,10 @@ impl<'a> SequenceMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - - 10
     ///       - false
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```

--- a/src/yaml/value.rs
+++ b/src/yaml/value.rs
@@ -236,27 +236,27 @@ impl<'a> Value<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     Hello World
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// assert!(matches!(doc.as_ref().into_any(), yaml::Any::Scalar(..)));
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     number1: 10
     ///     number2: 20
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// assert!(matches!(doc.as_ref().into_any(), yaml::Any::Mapping(..)));
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - 10
     ///     - 20
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// assert!(matches!(doc.as_ref().into_any(), yaml::Any::Sequence(..)));
@@ -281,27 +281,27 @@ impl<'a> Value<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     Hello World
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// assert!(matches!(doc.as_ref().as_any(), yaml::Any::Scalar(..)));
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     number1: 10
     ///     number2: 20
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// assert!(matches!(doc.as_ref().as_any(), yaml::Any::Mapping(..)));
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - 10
     ///     - 20
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// assert!(matches!(doc.as_ref().as_any(), yaml::Any::Sequence(..)));
@@ -333,10 +333,10 @@ impl<'a> Value<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     first: 32
     ///     second: [1, 2, 3]
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let root = doc.as_ref().as_mapping().context("missing mapping")?;
@@ -358,10 +358,10 @@ impl<'a> Value<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     first: 32
     ///     second: [1, 2, 3]
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let root = doc.as_ref().as_mapping().context("missing mapping")?;
@@ -543,11 +543,11 @@ impl<'a> Value<'a> {
     /// use nondestructive::yaml;
     ///
     /// let doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let root = doc.as_ref().as_sequence().context("missing root sequence")?;

--- a/src/yaml/value_mut.rs
+++ b/src/yaml/value_mut.rs
@@ -651,6 +651,37 @@ impl<'a> ValueMut<'a> {
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
+    ///
+    /// Making a new mapping inside of a sequence item:
+    ///
+    /// ```
+    /// use anyhow::Context;
+    /// use nondestructive::yaml;
+    ///
+    /// let mut doc = yaml::from_slice(
+    ///     r#"
+    ///     - one
+    ///     - two
+    ///     "#,
+    /// )?;
+    ///
+    /// let mut seq = doc.as_mut().into_sequence_mut().context("not a sequence")?;
+    /// let mut mapping = seq.push(yaml::Separator::Auto).make_mapping();
+    ///
+    /// mapping.insert_u32("three", 3);
+    /// mapping.insert_u32("four", 4);
+    ///
+    /// assert_eq!(
+    ///     doc.to_string(),
+    ///     r#"
+    ///     - one
+    ///     - two
+    ///     - three: 3
+    ///       four: 4
+    ///     "#
+    /// );
+    /// # Ok::<_, anyhow::Error>(())
+    /// ```
     #[inline]
     #[must_use]
     pub fn make_mapping(self) -> MappingMut<'a> {

--- a/src/yaml/value_mut.rs
+++ b/src/yaml/value_mut.rs
@@ -23,27 +23,27 @@ impl<'a> ValueMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     Hello World
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// assert!(matches!(doc.as_mut().into_any_mut(), yaml::AnyMut::Scalar(..)));
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     number1: 10
     ///     number2: 20
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// assert!(matches!(doc.as_mut().into_any_mut(), yaml::AnyMut::Mapping(..)));
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - 10
     ///     - 20
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// assert!(matches!(doc.as_mut().into_any_mut(), yaml::AnyMut::Sequence(..)));
@@ -201,13 +201,13 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     number1: 10
     ///     number2: 30
     ///     mapping:
     ///         inner: 400
     ///     string3: i-am-a-bare-string
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut root = doc.as_mut().into_mapping_mut().context("missing root mapping")?;
@@ -480,9 +480,9 @@ impl<'a> ValueMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     string
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// doc.as_mut().set_block(["foo", "bar", "baz"], yaml::Block::Literal(yaml::Chomp::Clip));
@@ -490,12 +490,12 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     |
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// doc.as_mut().set_block(["foo", "bar", "baz"], yaml::Block::Literal(yaml::Chomp::Keep));
@@ -503,12 +503,12 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     |+
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// doc.as_mut().set_block(["foo", "bar", "baz"], yaml::Block::Literal(yaml::Chomp::Strip));
@@ -516,12 +516,12 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     |-
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// doc.as_mut().set_block(["foo", "bar", "baz"], yaml::Block::Folded(yaml::Chomp::Clip));
@@ -529,12 +529,12 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     >
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// doc.as_mut().set_block(["foo", "bar", "baz"], yaml::Block::Folded(yaml::Chomp::Keep));
@@ -542,12 +542,12 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     >+
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     ///
     /// doc.as_mut().set_block(["foo", "bar", "baz"], yaml::Block::Folded(yaml::Chomp::Strip));
@@ -555,12 +555,12 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     >-
     ///       foo
     ///       bar
     ///       baz
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -614,9 +614,9 @@ impl<'a> ValueMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     string
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut mapping = doc.as_mut().make_mapping();
@@ -625,16 +625,16 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     first: 1
     ///     second: 2
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     first: second
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut mapping = doc.as_mut().into_mapping_mut().and_then(|m| Some(m.get_into_mut("first")?.make_mapping())).context("missing first")?;
@@ -643,11 +643,11 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     first:
     ///       second: 2
     ///       third: 3
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -659,10 +659,10 @@ impl<'a> ValueMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
-    ///     "#,
+    ///     ",
     /// )?;
     ///
     /// let mut seq = doc.as_mut().into_sequence_mut().context("not a sequence")?;
@@ -673,12 +673,12 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - one
     ///     - two
     ///     - three: 3
     ///       four: 4
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```
@@ -711,9 +711,9 @@ impl<'a> ValueMut<'a> {
     /// use nondestructive::yaml;
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     string
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut sequence = doc.as_mut().make_sequence();
@@ -722,16 +722,16 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     - 1
     ///     - 2
-    ///     "#
+    ///     "
     /// );
     ///
     /// let mut doc = yaml::from_slice(
-    ///     r#"
+    ///     r"
     ///     first: second
-    ///     "#
+    ///     "
     /// )?;
     ///
     /// let mut sequence = doc.as_mut().into_mapping_mut().and_then(|m| Some(m.get_into_mut("first")?.make_sequence())).context("missing first")?;
@@ -740,11 +740,11 @@ impl<'a> ValueMut<'a> {
     ///
     /// assert_eq!(
     ///     doc.to_string(),
-    ///     r#"
+    ///     r"
     ///     first:
     ///       - 2
     ///       - 3
-    ///     "#
+    ///     "
     /// );
     /// # Ok::<_, anyhow::Error>(())
     /// ```

--- a/tests/push-mapping.rs
+++ b/tests/push-mapping.rs
@@ -4,10 +4,10 @@ use nondestructive::yaml;
 #[test]
 fn push_mapping() -> Result<()> {
     let mut doc = yaml::from_slice(
-        r#"
+        r"
         - one
         - two
-        "#,
+        ",
     )?;
 
     let mut seq = doc.as_mut().into_sequence_mut().context("not a sequence")?;
@@ -22,7 +22,7 @@ fn push_mapping() -> Result<()> {
 
     assert_eq!(
         doc.to_string(),
-        r#"
+        r"
         - one
         - two
         - three: 3
@@ -30,7 +30,7 @@ fn push_mapping() -> Result<()> {
           five:
             six: six
             seven: seven
-        "#
+        "
     );
 
     Ok(())

--- a/tests/push-mapping.rs
+++ b/tests/push-mapping.rs
@@ -1,0 +1,37 @@
+use anyhow::{Context, Result};
+use nondestructive::yaml;
+
+#[test]
+fn push_mapping() -> Result<()> {
+    let mut doc = yaml::from_slice(
+        r#"
+        - one
+        - two
+        "#,
+    )?;
+
+    let mut seq = doc.as_mut().into_sequence_mut().context("not a sequence")?;
+    let mut mapping = seq.push(yaml::Separator::Auto).make_mapping();
+
+    mapping.insert_u32("three", 3);
+    mapping.insert_u32("four", 4);
+    let mut mapping2 = mapping.insert("five", yaml::Separator::Auto).make_mapping();
+
+    mapping2.insert_str("six", "six");
+    mapping2.insert_str("seven", "seven");
+
+    assert_eq!(
+        doc.to_string(),
+        r#"
+        - one
+        - two
+        - three: 3
+          four: 4
+          five:
+            six: six
+            seven: seven
+        "#
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
If we are an immediate child of a sequence item, then we want to be
nested at the same level as the item.

This allows for a more natural representation of sequences, like these:

```yaml
- one
- two: 2
    three: 3
```