### PR TITLE
More any values

### DIFF
--- a/src/yaml/any.rs
+++ b/src/yaml/any.rs
@@ -1,50 +1,115 @@
-use crate::yaml::{Id, Mapping, Sequence, Value};
+use crate::yaml::{Mapping, Number, Sequence, String};
 
 /// An enum which helps to externally discriminate the interior type of a
 /// [`Value`].
 ///
-/// See [`Value::into_any`][crate::yaml::Value::into_any].
-#[non_exhaustive]
+/// See [`Value::into_any`] or [`Value::as_any`].
+///
+/// [`Value::into_any`]: crate::yaml::Value::into_any
+/// [`Value::as_any`]: crate::yaml::Value::as_any
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Any<'a> {
-    /// The type is a scalar type.
-    Scalar(Value<'a>),
-    /// The type is a [`Mapping`].
+    /// A null value.
+    Null,
+    /// An boolean value.
+    Bool(bool),
+    /// A number value.
+    Number(Number<'a>),
+    /// A string value.
+    String(String<'a>),
+    /// A [`Mapping`] value.
     Mapping(Mapping<'a>),
-    /// The type is a [`Sequence`].
+    /// A [`Sequence`] value.
     Sequence(Sequence<'a>),
 }
 
-impl Any<'_> {
-    /// Coerce into [`Any`] to help discriminate the value type.
+impl<'a> Any<'a> {
+    /// Test if [`Any`] is null.
     ///
     /// # Examples
     ///
     /// ```
     /// use anyhow::Context;
+    /// use bstr::ByteSlice;
     /// use nondestructive::yaml;
     ///
-    /// let doc = yaml::from_slice(
-    ///     r"
-    ///     - 10
-    ///     - 20
-    ///     "
-    /// )?;
+    /// let doc = yaml::from_slice("null")?;
+    /// let doc = doc.as_ref();
     ///
-    /// let id = doc.as_ref().into_any().id();
-    ///
-    /// assert_eq!(
-    ///     doc.value(id).to_string(),
-    ///     "- 10\n    - 20"
-    /// );
+    /// assert!(doc.as_any().is_null());
     /// # Ok::<_, anyhow::Error>(())
     /// ```
-    #[must_use]
-    pub fn id(&self) -> Id {
+    pub fn is_null(self) -> bool {
+        matches!(self, Self::Null)
+    }
+
+    /// Coerce into [`Any`] into a bool.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use anyhow::Context;
+    /// use bstr::ByteSlice;
+    /// use nondestructive::yaml;
+    ///
+    /// let doc = yaml::from_slice("true")?;
+    /// let doc = doc.as_ref();
+    ///
+    /// let value = doc.as_any().into_bool().context("expected bool")?;
+    /// assert_eq!(value, true);
+    /// # Ok::<_, anyhow::Error>(())
+    /// ```
+    pub fn into_bool(self) -> Option<bool> {
         match self {
-            Any::Scalar(v) => v.id,
-            Any::Mapping(v) => v.id,
-            Any::Sequence(v) => v.id,
+            Self::Bool(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Coerce into [`Any`] into a string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use anyhow::Context;
+    /// use bstr::ByteSlice;
+    /// use nondestructive::yaml;
+    ///
+    /// let doc = yaml::from_slice(r#""Hello World""#)?;
+    /// let doc = doc.as_ref();
+    ///
+    /// let value = doc.as_any().into_string().context("expected string")?;
+    /// assert_eq!(value.to_str(), Ok("Hello World"));
+    /// # Ok::<_, anyhow::Error>(())
+    /// ```
+    pub fn into_string(self) -> Option<String<'a>> {
+        match self {
+            Self::String(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Coerce into [`Any`] into a string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use anyhow::Context;
+    /// use bstr::ByteSlice;
+    /// use nondestructive::yaml;
+    ///
+    /// let doc = yaml::from_slice("42")?;
+    /// let doc = doc.as_ref();
+    ///
+    /// let value = doc.as_any().into_number().context("expected number")?;
+    /// assert_eq!(value.as_u32(), Some(42));
+    /// # Ok::<_, anyhow::Error>(())
+    /// ```
+    pub fn into_number(self) -> Option<Number<'a>> {
+        match self {
+            Self::Number(value) => Some(value),
+            _ => None,
         }
     }
 }

--- a/src/yaml/any.rs
+++ b/src/yaml/any.rs
@@ -1,4 +1,4 @@
-use crate::yaml::{Mapping, Number, Sequence, String};
+use crate::yaml::{Mapping, Number, Sequence, String, Value};
 
 /// An enum which helps to externally discriminate the interior type of a
 /// [`Value`].
@@ -22,6 +22,8 @@ pub enum Any<'a> {
     Mapping(Mapping<'a>),
     /// A [`Sequence`] value.
     Sequence(Sequence<'a>),
+    /// A raw unrecognized value.
+    Raw(Value<'a>),
 }
 
 impl<'a> Any<'a> {
@@ -40,11 +42,12 @@ impl<'a> Any<'a> {
     /// assert!(doc.as_any().is_null());
     /// # Ok::<_, anyhow::Error>(())
     /// ```
+    #[must_use]
     pub fn is_null(self) -> bool {
         matches!(self, Self::Null)
     }
 
-    /// Coerce into [`Any`] into a bool.
+    /// Coerce [`Any`] into a bool.
     ///
     /// # Examples
     ///
@@ -60,6 +63,7 @@ impl<'a> Any<'a> {
     /// assert_eq!(value, true);
     /// # Ok::<_, anyhow::Error>(())
     /// ```
+    #[must_use]
     pub fn into_bool(self) -> Option<bool> {
         match self {
             Self::Bool(value) => Some(value),
@@ -67,7 +71,7 @@ impl<'a> Any<'a> {
         }
     }
 
-    /// Coerce into [`Any`] into a string.
+    /// Coerce [`Any`] into a string.
     ///
     /// # Examples
     ///
@@ -83,6 +87,7 @@ impl<'a> Any<'a> {
     /// assert_eq!(value.to_str(), Ok("Hello World"));
     /// # Ok::<_, anyhow::Error>(())
     /// ```
+    #[must_use]
     pub fn into_string(self) -> Option<String<'a>> {
         match self {
             Self::String(value) => Some(value),
@@ -90,7 +95,7 @@ impl<'a> Any<'a> {
         }
     }
 
-    /// Coerce into [`Any`] into a string.
+    /// Coerce [`Any`] into a string.
     ///
     /// # Examples
     ///
@@ -106,6 +111,7 @@ impl<'a> Any<'a> {
     /// assert_eq!(value.as_u32(), Some(42));
     /// # Ok::<_, anyhow::Error>(())
     /// ```
+    #[must_use]
     pub fn into_number(self) -> Option<Number<'a>> {
         match self {
             Self::Number(value) => Some(value),

--- a/src/yaml/any_mut.rs
+++ b/src/yaml/any_mut.rs
@@ -15,7 +15,7 @@ pub enum AnyMut<'a> {
 }
 
 impl AnyMut<'_> {
-    /// Coerce into [`AnyMut`] to help discriminate the value type.
+    /// Get [`AnyMut`] identifier.
     ///
     /// # Examples
     ///

--- a/src/yaml/data.rs
+++ b/src/yaml/data.rs
@@ -87,6 +87,7 @@ pub(crate) struct Data {
 impl Data {
     /// Get a string.
     #[inline]
+    #[must_use]
     pub(crate) fn str(&self, id: StringId) -> &BStr {
         let Some(string) = self.strings.get(&id) else {
             panic!("missing string with id {id}");

--- a/src/yaml/mapping/iter.rs
+++ b/src/yaml/mapping/iter.rs
@@ -29,7 +29,7 @@ impl<'a> Iterator for Iter<'a> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let item = self.data.mapping_item(*self.iter.next()?);
-        let key = self.data.str(item.key.string);
+        let key = self.data.str(item.key.id);
         let value = Value::new(self.data, item.value);
         Some((key, value))
     }
@@ -37,7 +37,7 @@ impl<'a> Iterator for Iter<'a> {
     #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let item = self.data.mapping_item(*self.iter.nth(n)?);
-        let key = self.data.str(item.key.string);
+        let key = self.data.str(item.key.id);
         let value = Value::new(self.data, item.value);
         Some((key, value))
     }
@@ -52,7 +52,7 @@ impl DoubleEndedIterator for Iter<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         let item = self.data.mapping_item(*self.iter.next_back()?);
-        let key = self.data.str(item.key.string);
+        let key = self.data.str(item.key.id);
         let value = Value::new(self.data, item.value);
         Some((key, value))
     }
@@ -60,7 +60,7 @@ impl DoubleEndedIterator for Iter<'_> {
     #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let item = self.data.mapping_item(*self.iter.nth(n)?);
-        let key = self.data.str(item.key.string);
+        let key = self.data.str(item.key.id);
         let value = Value::new(self.data, item.value);
         Some((key, value))
     }

--- a/src/yaml/mapping/mapping.rs
+++ b/src/yaml/mapping/mapping.rs
@@ -196,7 +196,7 @@ impl<'a> Mapping<'a> {
         for item in &self.data.mapping(self.id).items {
             let item = self.data.mapping_item(*item);
 
-            if self.data.str(item.key.string) == key {
+            if self.data.str(item.key.id) == key {
                 return Some(Value::new(self.data, item.value));
             }
         }

--- a/src/yaml/mapping/mapping_mut.rs
+++ b/src/yaml/mapping/mapping_mut.rs
@@ -164,7 +164,7 @@ impl<'a> MappingMut<'a> {
             return id;
         }
 
-        let key = raw::String::new(raw::RawStringKind::Bare, key);
+        let key = raw::String::new(raw::RawStringKind::Bare, key, key);
 
         let item_prefix = if self.data.mapping(self.id).items.last().is_some() {
             self.make_prefix()

--- a/src/yaml/mapping/mapping_mut.rs
+++ b/src/yaml/mapping/mapping_mut.rs
@@ -157,7 +157,7 @@ impl<'a> MappingMut<'a> {
             .items
             .iter()
             .map(|id| self.data.mapping_item(*id))
-            .find(|item| item.key.string == key)
+            .find(|item| item.key.id == key)
             .map(|item| item.value)
         {
             self.data.replace(id, value);
@@ -305,7 +305,7 @@ impl<'a> MappingMut<'a> {
         for item in &self.data.mapping(self.id).items {
             let item = self.data.mapping_item(*item);
 
-            if self.data.str(item.key.string) == key {
+            if self.data.str(item.key.id) == key {
                 return Some(ValueMut::new(self.data, item.value));
             }
         }
@@ -353,7 +353,7 @@ impl<'a> MappingMut<'a> {
         for item in &self.data.mapping(self.id).items {
             let item = self.data.mapping_item(*item);
 
-            if self.data.str(item.key.string) == key {
+            if self.data.str(item.key.id) == key {
                 return Some(ValueMut::new(self.data, item.value));
             }
         }
@@ -403,7 +403,7 @@ impl<'a> MappingMut<'a> {
         for (i, item) in self.data.mapping(self.id).items.iter().enumerate() {
             let item = self.data.mapping_item(*item);
 
-            if self.data.str(item.key.string) == key {
+            if self.data.str(item.key.id) == key {
                 index = Some(i);
                 break;
             }

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -82,6 +82,12 @@ pub use self::value::{Block, Chomp, Null, Separator, StringKind, Value};
 mod value_mut;
 pub use self::value_mut::ValueMut;
 
+mod number;
+pub use self::number::Number;
+
+mod string;
+pub use self::string::String;
+
 pub mod sequence;
 #[doc(inline)]
 pub use self::sequence::{Sequence, SequenceMut};

--- a/src/yaml/number.rs
+++ b/src/yaml/number.rs
@@ -71,6 +71,8 @@ impl<'a> Number<'a> {
     /// assert_eq!(value, "3.1415");
     /// # Ok::<_, anyhow::Error>(())
     /// ```
+    #[inline]
+    #[must_use]
     pub fn as_raw(&self) -> &BStr {
         self.data.str(self.raw.string)
     }

--- a/src/yaml/number.rs
+++ b/src/yaml/number.rs
@@ -1,0 +1,100 @@
+use core::fmt;
+
+use bstr::{BStr, ByteSlice};
+
+use crate::yaml::data::Data;
+use crate::yaml::raw;
+
+macro_rules! as_number {
+    ($name:ident, $ty:ty, $doc:literal, $lit:literal) => {
+        #[doc = concat!("Try and get the value as a ", $doc, ".")]
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use anyhow::Context;
+        /// use nondestructive::yaml;
+        ///
+        #[doc = concat!("let doc = yaml::from_slice(\"", stringify!($lit), "\")?;")]
+        /// let value = doc.as_ref().into_number().context("expected a number")?;
+        #[doc = concat!("let value = value.", stringify!($name), "();")]
+        #[doc = concat!("assert_eq!(value, Some(", stringify!($lit), "));")]
+        /// # Ok::<_, anyhow::Error>(())
+        /// ```
+        #[must_use]
+        pub fn $name(&self) -> Option<$ty> {
+            let string = self.data.str(self.raw.string);
+            lexical_core::parse(string).ok()
+        }
+    };
+}
+
+/// A YAML number.
+///
+/// The value of the number can be accessed through the various `as_*` methods.
+///
+/// # Examples
+///
+/// ```
+/// use anyhow::Context;
+/// use bstr::ByteSlice;
+/// use nondestructive::yaml;
+///
+/// let a = yaml::from_slice("42")?;
+/// let a = a.as_ref();
+///
+/// assert_eq!(a.as_u32(), Some(42));
+/// # Ok::<_, anyhow::Error>(())
+/// ```
+pub struct Number<'a> {
+    data: &'a Data,
+    raw: &'a raw::Number,
+}
+
+impl<'a> Number<'a> {
+    pub(super) fn new(data: &'a Data, raw: &'a raw::Number) -> Self {
+        Self { data, raw }
+    }
+
+    /// Get the raw content of the number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use anyhow::Context;
+    /// use nondestructive::yaml;
+    ///
+    /// let doc = yaml::from_slice("3.1415")?;
+    /// let doc = doc.as_ref();
+    /// let value = doc.as_number().context("expected a number")?;
+    /// let value = value.as_raw();
+    /// assert_eq!(value, "3.1415");
+    /// # Ok::<_, anyhow::Error>(())
+    /// ```
+    pub fn as_raw(&self) -> &BStr {
+        self.data.str(self.raw.string)
+    }
+
+    as_number!(as_f32, f32, "32-bit float", 10.42);
+    as_number!(as_f64, f64, "64-bit float", 10.42);
+    as_number!(as_u8, u8, "8-bit unsigned integer", 42);
+    as_number!(as_i8, i8, "8-bit signed integer", -42);
+    as_number!(as_u16, u16, "16-bit unsigned integer", 42);
+    as_number!(as_i16, i16, "16-bit signed integer", -42);
+    as_number!(as_u32, u32, "16-bit unsigned integer", 42);
+    as_number!(as_i32, i32, "32-bit signed integer", -42);
+    as_number!(as_u64, u64, "16-bit unsigned integer", 42);
+    as_number!(as_i64, i64, "64-bit signed integer", -42);
+    as_number!(as_u128, u128, "16-bit unsigned integer", 42);
+    as_number!(as_i128, i128, "128-bit signed integer", -42);
+}
+
+impl fmt::Debug for Number<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Ok(string) = self.as_raw().to_str() {
+            f.write_str(string)
+        } else {
+            f.write_str("NaN")
+        }
+    }
+}

--- a/src/yaml/parsing.rs
+++ b/src/yaml/parsing.rs
@@ -277,7 +277,13 @@ impl<'a> Parser<'a> {
 
         let string = self.data.insert_str(self.string(start));
         self.bump(usize::from(!self.is_eof()));
-        Raw::String(raw::String::new(raw::RawStringKind::Single, string))
+        let original = self.data.insert_str(self.string(original));
+
+        Raw::String(raw::String::new(
+            raw::RawStringKind::Original,
+            string,
+            original,
+        ))
     }
 
     /// Read a single-quoted escaped string.
@@ -307,8 +313,9 @@ impl<'a> Parser<'a> {
         let original = self.data.insert_str(self.string(original));
 
         Raw::String(raw::String::new(
-            raw::RawStringKind::Original { original },
+            raw::RawStringKind::Original,
             string,
+            original,
         ))
     }
 
@@ -332,10 +339,12 @@ impl<'a> Parser<'a> {
 
         let string = self.data.insert_str(self.string(start));
         self.bump(usize::from(!self.is_eof()));
+        let original = self.data.insert_str(self.string(original));
 
         Ok(Raw::String(raw::String::new(
-            raw::RawStringKind::Double,
+            raw::RawStringKind::Original,
             string,
+            original,
         )))
     }
 
@@ -365,8 +374,9 @@ impl<'a> Parser<'a> {
         let original = self.data.insert_str(self.string(original));
 
         Ok(Raw::String(raw::String::new(
-            raw::RawStringKind::Original { original },
+            raw::RawStringKind::Original,
             string,
+            original,
         )))
     }
 
@@ -693,7 +703,7 @@ impl<'a> Parser<'a> {
             // followed by spacing.
             if a == b':' && is_spacing(b) {
                 let key = self.data.insert_str(self.string(start));
-                return Some(raw::String::new(raw::RawStringKind::Bare, key));
+                return Some(raw::String::new(raw::RawStringKind::Bare, key, key));
             }
 
             self.bump(1);
@@ -711,7 +721,7 @@ impl<'a> Parser<'a> {
         }
 
         let key = self.data.insert_str(self.string(start));
-        Some(raw::String::new(raw::RawStringKind::Bare, key))
+        Some(raw::String::new(raw::RawStringKind::Bare, key, key))
     }
 
     /// Process a block as a string.
@@ -777,8 +787,11 @@ impl<'a> Parser<'a> {
         let out = self.input.get(start..end).unwrap_or_default();
         let original = self.data.insert_str(out);
 
-        let kind = raw::RawStringKind::Multiline { prefix, original };
-        (Raw::String(raw::String::new(kind, string)), Some(ws))
+        let kind = raw::RawStringKind::Multiline { prefix };
+        (
+            Raw::String(raw::String::new(kind, string, original)),
+            Some(ws),
+        )
     }
 
     /// Consume a single value.
@@ -833,7 +846,7 @@ impl<'a> Parser<'a> {
                         b"false" => (Raw::Boolean(false), None),
                         string => {
                             let string = self.data.insert_str(string);
-                            let string = raw::String::new(raw::RawStringKind::Bare, string);
+                            let string = raw::String::new(raw::RawStringKind::Bare, string, string);
                             (Raw::String(string), None)
                         }
                     }
@@ -867,7 +880,7 @@ impl<'a> Parser<'a> {
         };
 
         let string = self.data.insert_str(string);
-        Some(raw::String::new(raw::RawStringKind::Bare, string))
+        Some(raw::String::new(raw::RawStringKind::Bare, string, string))
     }
 }
 

--- a/src/yaml/raw.rs
+++ b/src/yaml/raw.rs
@@ -44,7 +44,7 @@ where
 {
     let kind = RawStringKind::detect(string.as_ref());
     let string = data.insert_str(string.as_ref());
-    Raw::String(String::new(kind, string))
+    Raw::String(String::new(kind, string, string))
 }
 
 /// Construct an indentation prefix.
@@ -127,7 +127,7 @@ where
     };
 
     let string = data.insert_str(string.as_ref());
-    Raw::String(String::new(kind, string))
+    Raw::String(String::new(kind, string, string))
 }
 
 /// Construct a block with the given configuration.
@@ -167,10 +167,8 @@ where
 
     let original = data.insert_str(&original);
     let string = data.insert_str(out);
-    Raw::String(self::String::new(
-        RawStringKind::Original { original },
-        string,
-    ))
+
+    Raw::String(self::String::new(RawStringKind::Original, string, original))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -364,12 +362,9 @@ pub(crate) enum RawStringKind {
     /// A double-quoted string.
     Double,
     /// An escaped string, where the string id points to the original string.
-    Original { original: StringId },
+    Original,
     /// A multiline string.
-    Multiline {
-        prefix: StringId,
-        original: StringId,
-    },
+    Multiline { prefix: StringId },
 }
 
 impl RawStringKind {
@@ -414,12 +409,18 @@ pub(crate) struct String {
     pub(crate) kind: RawStringKind,
     /// The content of the string.
     pub(crate) string: StringId,
+    /// The original contents of the string.
+    pub(crate) original: StringId,
 }
 
 impl String {
     /// A simple number.
-    pub(crate) fn new(kind: RawStringKind, string: StringId) -> Self {
-        Self { kind, string }
+    pub(crate) fn new(kind: RawStringKind, string: StringId, original: StringId) -> Self {
+        Self {
+            kind,
+            string,
+            original,
+        }
     }
 
     fn display(&self, data: &Data, f: &mut fmt::Formatter) -> fmt::Result {
@@ -494,12 +495,12 @@ impl String {
                 let string = data.str(self.string);
                 escape_single_quoted(string, f)?;
             }
-            RawStringKind::Original { original } => {
-                let string = data.str(*original);
+            RawStringKind::Original => {
+                let string = data.str(self.original);
                 write!(f, "{string}")?;
             }
-            RawStringKind::Multiline { prefix, original } => {
-                let string = data.str(*original);
+            RawStringKind::Multiline { prefix } => {
+                let string = data.str(self.original);
                 write!(f, "{}{string}", data.str(*prefix))?;
             }
         }
@@ -588,12 +589,12 @@ impl String {
                 let string = data.str(self.string);
                 escape_single_quoted(string, o)?;
             }
-            RawStringKind::Original { original } => {
-                o.write_all(data.str(*original))?;
+            RawStringKind::Original => {
+                o.write_all(data.str(self.original))?;
             }
-            RawStringKind::Multiline { prefix, original } => {
+            RawStringKind::Multiline { prefix } => {
                 o.write_all(data.str(*prefix))?;
-                o.write_all(data.str(*original))?;
+                o.write_all(data.str(self.original))?;
             }
         }
 

--- a/src/yaml/raw.rs
+++ b/src/yaml/raw.rs
@@ -408,19 +408,15 @@ pub(crate) struct String {
     /// The kind of the string.
     pub(crate) kind: RawStringKind,
     /// The content of the string.
-    pub(crate) string: StringId,
+    pub(crate) id: StringId,
     /// The original contents of the string.
     pub(crate) original: StringId,
 }
 
 impl String {
     /// A simple number.
-    pub(crate) fn new(kind: RawStringKind, string: StringId, original: StringId) -> Self {
-        Self {
-            kind,
-            string,
-            original,
-        }
+    pub(crate) fn new(kind: RawStringKind, id: StringId, original: StringId) -> Self {
+        Self { kind, id, original }
     }
 
     fn display(&self, data: &Data, f: &mut fmt::Formatter) -> fmt::Result {
@@ -484,15 +480,15 @@ impl String {
 
         match &self.kind {
             RawStringKind::Bare => {
-                let string = data.str(self.string);
+                let string = data.str(self.id);
                 write!(f, "{string}")?;
             }
             RawStringKind::Double => {
-                let string = data.str(self.string);
+                let string = data.str(self.id);
                 escape_double_quoted(string, f)?;
             }
             RawStringKind::Single => {
-                let string = data.str(self.string);
+                let string = data.str(self.id);
                 escape_single_quoted(string, f)?;
             }
             RawStringKind::Original => {
@@ -579,14 +575,14 @@ impl String {
 
         match &self.kind {
             RawStringKind::Bare => {
-                o.write_all(data.str(self.string))?;
+                o.write_all(data.str(self.id))?;
             }
             RawStringKind::Double => {
-                let string = data.str(self.string);
+                let string = data.str(self.id);
                 escape_double_quoted(string, o)?;
             }
             RawStringKind::Single => {
-                let string = data.str(self.string);
+                let string = data.str(self.id);
                 escape_single_quoted(string, o)?;
             }
             RawStringKind::Original => {
@@ -874,7 +870,7 @@ pub(crate) struct MappingItem {
 
 impl MappingItem {
     fn display(&self, data: &Data, f: &mut fmt::Formatter) -> fmt::Result {
-        let key = data.str(self.key.string);
+        let key = data.str(self.key.id);
         write!(f, "{key}:")?;
         data.raw(self.value).display(data, f, Some(self.value))?;
         Ok(())
@@ -884,7 +880,7 @@ impl MappingItem {
     where
         O: ?Sized + io::Write,
     {
-        o.write_all(data.str(self.key.string))?;
+        o.write_all(data.str(self.key.id))?;
         write!(o, ":")?;
         o.write_all(data.prefix(self.value))?;
         data.raw(self.value).write_to(data, o)?;

--- a/src/yaml/serde/de.rs
+++ b/src/yaml/serde/de.rs
@@ -54,7 +54,7 @@ impl<'de> Deserializer<'de> for Value<'de> {
                 RawNumberHint::Signed128 => self.deserialize_i128(visitor),
             },
             raw::Raw::String(raw) => {
-                let string = self.data.str(raw.string);
+                let string = self.data.str(raw.id);
 
                 if let Ok(string) = string.to_str() {
                     visitor.visit_borrowed_str(string)

--- a/src/yaml/serde/ser.rs
+++ b/src/yaml/serde/ser.rs
@@ -66,7 +66,7 @@ impl Serialize for Value<'_> {
                 },
             },
             raw::Raw::String(raw) => {
-                let string = self.data.str(raw.string);
+                let string = self.data.str(raw.id);
 
                 if let Ok(string) = string.to_str() {
                     serializer.serialize_str(string)

--- a/src/yaml/string.rs
+++ b/src/yaml/string.rs
@@ -1,0 +1,94 @@
+use core::fmt;
+use core::ops::Deref;
+
+use bstr::BStr;
+
+use crate::yaml::data::Data;
+use crate::yaml::raw;
+
+/// A YAML string.
+///
+/// The string is accessed through a [`BStr`] coercion, since strings might
+/// contain non-utf8 data.
+///
+/// Use utilities such as [`bstr::ByteSlice::to_str`] to coerce it into a
+/// [`str`].
+///
+/// # Examples
+///
+/// ```
+/// use anyhow::Context;
+/// use bstr::ByteSlice;
+/// use nondestructive::yaml;
+///
+/// let a = yaml::from_slice(r#""Hello\n World""#)?;
+/// let a = a.as_ref();
+///
+/// let a = a.as_any().into_string().context("expected string")?;
+/// let a = a.to_str()?;
+/// assert_eq!(a, "Hello\n World");
+/// # Ok::<_, anyhow::Error>(())
+/// ```
+pub struct String<'a> {
+    data: &'a Data,
+    raw: &'a raw::String,
+}
+
+impl<'a> String<'a> {
+    pub(super) fn new(data: &'a Data, raw: &'a raw::String) -> Self {
+        Self { data, raw }
+    }
+
+    /// Get the raw contents of the string, as it's being referenced.
+    ///
+    /// For strings which contains an escape sequence, the whole string content
+    /// will be referenced including any parenthesis.
+    ///
+    /// For other strings, only the contents of the string is referenced.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use anyhow::Context;
+    /// use nondestructive::yaml;
+    ///
+    /// let a = yaml::from_slice(r#""Hello\n World""#)?;
+    /// let a = a.as_ref();
+    ///
+    /// let a = a.as_any().into_string().context("expected string")?;
+    /// let a = a.as_raw();
+    /// assert_eq!(a, "\"Hello\\n World\"");
+    ///
+    /// let b = yaml::from_slice(r#""Hello World""#)?;
+    /// let b = b.as_ref();
+    ///
+    /// let b = b.as_any().into_string().context("expected string")?;
+    /// let b = b.as_raw();
+    /// assert_eq!(b, "Hello World");
+    /// # Ok::<_, anyhow::Error>(())
+    /// ```
+    #[inline]
+    pub fn as_raw(&self) -> &BStr {
+        match self.raw.kind {
+            raw::RawStringKind::Original { original }
+            | raw::RawStringKind::Multiline { original, .. } => self.data.str(original),
+            _ => self.data.str(self.raw.string),
+        }
+    }
+}
+
+impl Deref for String<'_> {
+    type Target = BStr;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.data.str(self.raw.string)
+    }
+}
+
+impl fmt::Debug for String<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.data.str(self.raw.string).fmt(f)
+    }
+}

--- a/src/yaml/string.rs
+++ b/src/yaml/string.rs
@@ -65,6 +65,7 @@ impl<'a> String<'a> {
     /// # Ok::<_, anyhow::Error>(())
     /// ```
     #[inline]
+    #[must_use]
     pub fn as_raw(&self) -> &BStr {
         self.data.str(self.raw.original)
     }
@@ -75,13 +76,13 @@ impl Deref for String<'_> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.data.str(self.raw.string)
+        self.data.str(self.raw.id)
     }
 }
 
 impl fmt::Debug for String<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.data.str(self.raw.string).fmt(f)
+        self.data.str(self.raw.id).fmt(f)
     }
 }

--- a/src/yaml/string.rs
+++ b/src/yaml/string.rs
@@ -39,12 +39,8 @@ impl<'a> String<'a> {
         Self { data, raw }
     }
 
-    /// Get the raw contents of the string, as it's being referenced.
-    ///
-    /// For strings which contains an escape sequence, the whole string content
-    /// will be referenced including any parenthesis.
-    ///
-    /// For other strings, only the contents of the string is referenced.
+    /// Get the raw contents of the string, as it's being referenced during
+    /// parsing or insertion.
     ///
     /// # Examples
     ///
@@ -53,27 +49,24 @@ impl<'a> String<'a> {
     /// use nondestructive::yaml;
     ///
     /// let a = yaml::from_slice(r#""Hello\n World""#)?;
-    /// let a = a.as_ref();
-    ///
-    /// let a = a.as_any().into_string().context("expected string")?;
+    /// let a = a.as_ref().into_any().into_string().context("expected string")?;
     /// let a = a.as_raw();
     /// assert_eq!(a, "\"Hello\\n World\"");
     ///
     /// let b = yaml::from_slice(r#""Hello World""#)?;
-    /// let b = b.as_ref();
-    ///
-    /// let b = b.as_any().into_string().context("expected string")?;
+    /// let b = b.as_ref().into_any().into_string().context("expected string")?;
     /// let b = b.as_raw();
-    /// assert_eq!(b, "Hello World");
+    /// assert_eq!(b, "\"Hello World\"");
+    ///
+    /// let c = yaml::from_slice("'Hello World'")?;
+    /// let c = c.as_ref().into_any().into_string().context("expected string")?;
+    /// let c = c.as_raw();
+    /// assert_eq!(c, "'Hello World'");
     /// # Ok::<_, anyhow::Error>(())
     /// ```
     #[inline]
     pub fn as_raw(&self) -> &BStr {
-        match self.raw.kind {
-            raw::RawStringKind::Original { original }
-            | raw::RawStringKind::Multiline { original, .. } => self.data.str(original),
-            _ => self.data.str(self.raw.string),
-        }
+        self.data.str(self.raw.original)
     }
 }
 

--- a/src/yaml/value.rs
+++ b/src/yaml/value.rs
@@ -265,7 +265,7 @@ impl<'a> Value<'a> {
             Raw::String(string) => Any::String(String::new(self.data, string)),
             Raw::Mapping(..) => Any::Mapping(Mapping::new(self.data, self.id)),
             Raw::Sequence(..) => Any::Sequence(Sequence::new(self.data, self.id)),
-            _ => panic!("Not a valid value"),
+            _ => Any::Raw(self),
         }
     }
 
@@ -310,7 +310,7 @@ impl<'a> Value<'a> {
             Raw::String(string) => Any::String(String::new(self.data, string)),
             Raw::Mapping(..) => Any::Mapping(Mapping::new(self.data, self.id)),
             Raw::Sequence(..) => Any::Sequence(Sequence::new(self.data, self.id)),
-            _ => panic!("Not a valid value"),
+            _ => Any::Raw(Value::new(self.data, self.id)),
         }
     }
 
@@ -406,7 +406,7 @@ impl<'a> Value<'a> {
     #[must_use]
     pub fn as_bstr(&self) -> Option<&'a BStr> {
         match self.data.raw(self.id) {
-            Raw::String(raw) => Some(self.data.str(raw.string)),
+            Raw::String(raw) => Some(self.data.str(raw.id)),
             _ => None,
         }
     }
@@ -480,7 +480,7 @@ impl<'a> Value<'a> {
     #[must_use]
     pub fn as_str(&self) -> Option<&'a str> {
         match self.data.raw(self.id) {
-            Raw::String(raw) => self.data.str(raw.string).to_str().ok(),
+            Raw::String(raw) => self.data.str(raw.id).to_str().ok(),
             _ => None,
         }
     }


### PR DESCRIPTION
This adds more support for particularly dealing with `Any` values, introducing helpers to decode strings and numbers without having to coerce them to specific types.